### PR TITLE
bring auth tokens into local scope for POST functions

### DIFF
--- a/AFK-Server/index.php
+++ b/AFK-Server/index.php
@@ -30,7 +30,8 @@ $app->post(
 $app->post(
 	'/afk', 
 	 function () use ($app) {
-		 
+		
+	global $afkToken;
 	$auth = $_POST['token'];
 
 	if ($auth != $afkToken) {
@@ -106,7 +107,8 @@ $app->post(
 $app->post(
 	'/whereis', 
 	 function () use ($app) {
-		 
+
+	global $whereisToken;
 	$auth = $_POST['token'];
 
 	if ($auth != $whereisToken) {


### PR DESCRIPTION
In my build I found that the slash command kept returning "Not Authorised." This was down to the auth Tokens not being populated when they were being checked. Globalising them may not be the best solution but it does resolve this issue.